### PR TITLE
Update and rename submissionRuleV2_0.adoc to submissionRuleV2_1.adoc

### DIFF
--- a/rules/submissionRuleV2_1.adoc
+++ b/rules/submissionRuleV2_1.adoc
@@ -118,7 +118,7 @@
 **** <device_id>.json
 *** calibration.md  # quantization writeup
 
-*<Benchmark name>* = {mobilenetEdgeTPU, mobiledetSSD, mobileBERT, deeplabV3+, mosaic} +
+*<Benchmark name>* = {mobilenetEdgeTPU, mobiledetSSD, mobileBERT, mosaic} +
 *<scenario>* = {SingleStream, Offline}
 
 === Post-Submission Review/Audit


### PR DESCRIPTION
update filename and remove deeplabV3+, which is obsolete